### PR TITLE
Create d2l-user-tile when the token param is not provided

### DIFF
--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -105,7 +105,10 @@
 				type: String,
 				value: null
 			},
-			token: String
+			token: {
+				type: String,
+				value: null
+			}
 		},
 		listeners: {
 			'd2l-image-failed-to-load': '_onImageLoadFailure'


### PR DESCRIPTION
Didn't take into account relative images when switching to `d2l-image` component. 
Related to: #18 