### PR TITLE
add low-lift hover effect to the user tile

### DIFF
--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -77,7 +77,7 @@
 			}
 		</style>
 
-		<d2l-tile img-url="[[background]]" style$="[[_createBackgroundStyle(backgroundColor)]]">
+		<d2l-tile img-url="[[background]]" style$="[[_createBackgroundStyle(backgroundColor)]]" hover-effect="low-lift">
 			<div class="user-tile-avatar">
 				<template is="dom-if" if="{{_hideCustomIcon(icon)}}">
 					<d2l-icon icon="navigation-48:profile" class="user-tile-default-icon"></d2l-icon>


### PR DESCRIPTION
Together, this group of PRs adds hover effects to User-tile, Evidence-tile, and fixes a bug where tabbing through the evidence tiles in PP would highlight their d2l-menus

https://rally1.rallydev.com/#/95185052972d/detail/userstory/117818565584?fdp=true
https://rally1.rallydev.com/#/89963236876d/detail/userstory/117681744096

Related:
https://github.com/Brightspace/d2l-tile/pull/7
https://github.com/Brightspace/parent-portal-ui/pull/150
https://github.com/Brightspace/d2l-evidence-tile/pull/11