### PR TITLE
US87150 - User tile fade in

### DIFF
--- a/d2l-user-tile-auto.html
+++ b/d2l-user-tile-auto.html
@@ -26,7 +26,7 @@
 			background="[[_backgroundUrl]]"
 			background-color="[[_backgroundColor]]"
 			token="[[token]]"
-			placeholders="[[placeholders]]"
+			placeholders="[[!_doneRequests]]"
 		>
 			<slot></slot>
 		</d2l-user-tile>
@@ -44,8 +44,7 @@
 			userUrl: {
 				type: String,
 				value: null
-			},
-			placeholders: Boolean
+			}
 		},
 
 		observers: [

--- a/d2l-user-tile-auto.html
+++ b/d2l-user-tile-auto.html
@@ -44,7 +44,8 @@
 			userUrl: {
 				type: String,
 				value: null
-			}
+			},
+			_doneRequests: Boolean
 		},
 
 		observers: [

--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -66,21 +66,30 @@
 			[hidden] {
 				display: none;
 			}
+
+			@keyframes fade-out-then-in {
+				0% { opacity: 1; }
+				50% { opacity: 0; }
+				100% { opacity: 1; }
+			}
+
+			:host([prev-placeholders]:not([placeholders])) {
+				animation: fade-out-then-in 0.33s forwards;
+			}
 		</style>
 
-		<d2l-tile img-url="[[background]]" style$="[[_createBackgroundStyle(backgroundColor)]]" hover-effect="low-lift">
+		<d2l-tile img-url="[[_getImgUrl(background, _placeholders)]]" style$="[[_createBackgroundStyle(backgroundColor, _placeholders)]]" hover-effect="low-lift">
 			<div class="user-tile-avatar">
-				<template is="dom-if" if="[[!_hideIconPlaceholder(icon)]]">
+				<template is="dom-if" if="[[!_hideIconPlaceholder(icon, _placeholders)]]">
 					<d2l-icon icon="navigation-48:profile" class="user-tile-default-icon"></d2l-icon>
 				</template>
-				<template is="dom-if" if="[[_hideIconPlaceholder(icon)]]">
+				<template is="dom-if" if="[[_hideIconPlaceholder(icon, _placeholders)]]">
 					<d2l-image image-url="[[icon]]" token="[[token]]"></d2l-image>
 				</template>
 			</div>
 			<div class="user-tile-information-wrapper">
-				<p class="user-tile-name" hidden$="[[!_hideNamePlaceholder(placeholders, name)]]">[[name]]</p>
-				<p class="user-tile-name text-placeholder" hidden$="[[_hideNamePlaceholder(placeholders, name)]]">&nbsp;</p>
-
+				<p class="user-tile-name" hidden$="[[!_hideNamePlaceholder(_placeholders, name)]]">[[name]]</p>
+				<p class="user-tile-name text-placeholder" hidden$="[[_hideNamePlaceholder(_placeholders, name)]]">&nbsp;</p>
 				<div class="user-tile-items">
 					<slot></slot>
 				</div>
@@ -105,11 +114,17 @@
 			},
 			placeholders: {
 				type: Boolean,
-				value: false
+				value: false,
+				reflectToAttribute: 'true',
+				observer: '_updatePlaceholders'
 			},
 			token: {
 				type: String,
 				value: null
+			},
+			_placeholders: {
+				type: Boolean,
+				value: false
 			}
 		},
 
@@ -117,21 +132,35 @@
 			'd2l-image-failed-to-load': '_onImageLoadFailure'
 		},
 
-		_hideIconPlaceholder: function(icon) {
-			return !!icon;
+		_updatePlaceholders: function(placeholders, oldVal) {
+			if (oldVal || placeholders) {
+				this.setAttribute('prev-placeholders', true);
+			}
+
+			setTimeout(function() {
+				this._placeholders = placeholders;
+			}.bind(this), 160);
+		},
+
+		_hideIconPlaceholder: function(icon, placeholders) {
+			return !placeholders && !!icon;
 		},
 
 		_hideNamePlaceholder: function(placeholders, name) {
-			return !placeholders || 'string' === typeof name;
+			return !placeholders && 'string' === typeof name;
 		},
 
-		_createBackgroundStyle: function(backgroundColor) {
-			this.customStyle['--tile-image-background'] = backgroundColor || '';
+		_createBackgroundStyle: function(backgroundColor, placeholders) {
+			this.customStyle['--tile-image-background'] = (placeholders) ? '' : backgroundColor || '';
 			this.updateStyles();
 		},
 
 		_onImageLoadFailure: function() {
 			this.icon = null;
+		},
+
+		_getImgUrl: function(background, placeholders) {
+			return placeholders ? null : background;
 		}
 	});
 	</script>

--- a/test/d2l-user-tile-auto/d2l-user-tile-auto.html
+++ b/test/d2l-user-tile-auto/d2l-user-tile-auto.html
@@ -17,7 +17,7 @@
 
 		<test-fixture id="with-placeholders">
 			<template>
-				<d2l-user-tile-auto placeholders>
+				<d2l-user-tile-auto done-requests="true">
 				</d2l-user-tile-auto>
 			</template>
 		</test-fixture>

--- a/test/d2l-user-tile-auto/d2l-user-tile-auto.js
+++ b/test/d2l-user-tile-auto/d2l-user-tile-auto.js
@@ -77,11 +77,14 @@ describe('<d2l-user-tile-auto>', function() {
 		});
 	});
 
-	describe('content placeholders', function() {
+	describe('content placeholders', function(done) {
 		it('should set the placeholder property on the internal <d2l-user-tile>', function() {
 			component = fixture('with-placeholders');
 			var internalTile = component.$$('d2l-user-tile');
-			expect(internalTile.placeholders).to.be.true;
+			setTimeout(function() {
+				expect(internalTile.placeholders).to.be.true;
+				done();
+			}, 200);
 		});
 	});
 });

--- a/test/d2l-user-tile-auto/d2l-user-tile-auto.js
+++ b/test/d2l-user-tile-auto/d2l-user-tile-auto.js
@@ -57,6 +57,8 @@ describe('<d2l-user-tile-auto>', function() {
 		});
 
 		it('sets the properties on the internal <d2l-user-tile> appropriately', function(done) {
+			var innerTile = component.$$('d2l-user-tile');
+			sandbox.stub(innerTile, '_onImageLoadFailure', function() {});
 			sandbox.stub(component, 'generateUserRequest', function() {
 				component._name = 'name';
 				component._iconUrl = 'iconUrl';
@@ -67,7 +69,6 @@ describe('<d2l-user-tile-auto>', function() {
 			component.token = token;
 			component.userUrl = userUrl;
 			setTimeout(function() {
-				var innerTile = component.$$('d2l-user-tile');
 				expect(innerTile.name).to.equal('name');
 				expect(innerTile.icon).to.equal('iconUrl');
 				expect(innerTile.background).to.equal('backgroundUrl');


### PR DESCRIPTION
The skeleton is now all-or-nothing, 

When you toggle the skeleton on/off, the tile fades out, and then reappears as a new much-more-fulfilled kind of tile

Also: https://github.com/Brightspace/user-profile-behavior/pull/13