### PR TITLE
US88458 - Add bottom padding to select profile

### DIFF
--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -43,7 +43,8 @@
 				@apply --d2l-body-compact-text;
 				display: flex;
 				flex-direction: column;
-				min-height: 110px;
+				padding-bottom: 30px;
+				min-height: 80px;
 			}
 
 			.user-tile-name {

--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -43,6 +43,7 @@
 				@apply --d2l-body-compact-text;
 				display: flex;
 				flex-direction: column;
+				min-height: 110px;
 			}
 
 			.user-tile-name {


### PR DESCRIPTION
[Story 88458](https://rally1.rallydev.com/#/89963236876d/detail/userstory/133702954036).
[Related PR 309 in parent-portal-ui](https://github.com/Brightspace/parent-portal-ui/pull/309).

Select Profile user tiles will now always have a bottom padding of 30px so things sit comfortably off the border. When there is no content besides the child name there should be about 85px between the name and the bottom border.