### PR TITLE
Bump deps to fix regression

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,12 +18,12 @@
   ],
   "dependencies": {
     "d2l-ajax": "^3.2.6",
-    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^1.0.0",
+    "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^2.0.0",
     "d2l-icons": "^3.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0",
     "d2l-tile": "git://github.com/Brightspace/d2l-tile#^1.0.2",
     "d2l-image": "git://github.com/Brightspace/d2l-image#^1.1.0",
-    "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^2.0.0",
+    "d2l-user-profile-behavior": "git://github.com/Brightspace/user-profile-behavior#^2.0.1",
     "polymer": "^1.8.0",
     "d2l-colors": "^2.3.0"
   },


### PR DESCRIPTION
The theme rels changed namespace in d2l-hm-constants-behavior#2.0.0. We're forcefully using the newer version downstream in parent-portal-ui, so the tile isn't able to fetch the org colour (from the theme request) for the tile.