### PR TITLE
Remove d2l-ajax in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,6 @@
     "tests"
   ],
   "dependencies": {
-    "d2l-ajax": "^3.2.6",
     "d2l-hm-constants-behavior": "git://github.com/Brightspace/d2l-hm-constants-behavior.git#^2.0.0",
     "d2l-icons": "^3.0.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.0",


### PR DESCRIPTION
Far as I can tell this was never actually used anyway - been here since the first commit, probs copied over from another repo. Either way, definitely not used anymore!