### PR TITLE
Remove unneeded siren-parser reference

### DIFF
--- a/d2l-user-tile-auto.html
+++ b/d2l-user-tile-auto.html
@@ -38,7 +38,6 @@
 			<slot></slot>
 		</d2l-user-tile>
 	</template>
-	<script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 	<script>
 	'use strict';
 	Polymer({


### PR DESCRIPTION
Not actually being used; I suspect its usage was removed when d2l-hm-organization-behavior was introduced.