### PR TITLE
Remove d2l-image and rely on cookie + pluggable permissions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.2.0",
     "d2l-colors": "^3.1.2",
-    "d2l-icons": "^4.9.0",
-    "d2l-image": "Brightspace/d2l-image#^2.0.0",
+    "d2l-icons": "^5.0.0",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.3",
     "d2l-tile": "^3.0.3",
     "d2l-user-profile-behavior": "Brightspace/user-profile-behavior#^3.0.1",

--- a/d2l-user-tile-auto.html
+++ b/d2l-user-tile-auto.html
@@ -32,7 +32,6 @@
 			icon="[[_iconUrl]]"
 			background="[[_backgroundUrl]]"
 			background-color="[[_backgroundColor]]"
-			token="[[token]]"
 			placeholders="[[!_doneRequests]]"
 		>
 			<slot></slot>

--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -2,7 +2,6 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-tile/d2l-image-tile.html">
-<link rel="import" href="../d2l-image/d2l-image.html">
 <link rel="import" href="icons.html">
 <!--
 `d2l-user-tile` is a Polymer-based web component for creating a user tile.
@@ -33,6 +32,11 @@
 				margin: -40px auto 19px auto;
 				background-color: var(--d2l-color-white);
 				overflow: hidden;
+			}
+
+			.user-tile-avatar > img {
+				width: 100%;
+				height: 100%;
 			}
 
 			.user-tile-items {
@@ -105,7 +109,7 @@
 					<d2l-icon icon="navigation-48:profile" class="user-tile-default-icon"></d2l-icon>
 				</template>
 				<template is="dom-if" if="[[_hideIconPlaceholder(icon, _placeholders)]]">
-					<d2l-image image-url="[[icon]]" token="[[token]]"></d2l-image>
+					<img src=[[icon]] />
 				</template>
 			</div>
 			<div class="user-tile-information-wrapper">
@@ -139,18 +143,10 @@
 				reflectToAttribute: 'true',
 				observer: '_updatePlaceholders'
 			},
-			token: {
-				type: String,
-				value: null
-			},
 			_placeholders: {
 				type: Boolean,
 				value: false
 			}
-		},
-
-		listeners: {
-			'd2l-image-failed-to-load': '_onImageLoadFailure'
 		},
 
 		_updatePlaceholders: function(placeholders, oldVal) {
@@ -173,10 +169,6 @@
 
 		_createBackgroundStyle: function(backgroundColor, placeholders) {
 			this.updateStyles({'--d2l-image-tile-image-background': (placeholders) ? '' : backgroundColor || ''});
-		},
-
-		_onImageLoadFailure: function() {
-			this.icon = null;
 		},
 
 		_getImgUrl: function(background, placeholders) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "eslint": "^4.17.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.2",
-    "polymer-cli": "^1.6.0"
+    "polymer-cli": "^1.7.7"
   }
 }

--- a/test/d2l-user-tile-auto/d2l-user-tile-auto.js
+++ b/test/d2l-user-tile-auto/d2l-user-tile-auto.js
@@ -92,7 +92,6 @@ describe('<d2l-user-tile-auto>', function() {
 
 			it('sets the properties on the internal <d2l-user-tile> appropriately', function(done) {
 				var innerTile = component.$$('d2l-user-tile');
-				sandbox.stub(innerTile, '_onImageLoadFailure', function() {});
 				sandbox.stub(component, 'generateUserRequest', function() {
 					component._name = 'name';
 					component._iconUrl = 'iconUrl';

--- a/test/d2l-user-tile/d2l-user-tile.js
+++ b/test/d2l-user-tile/d2l-user-tile.js
@@ -20,7 +20,7 @@ describe('<d2l-user-tile>', function() {
 		describe('when the `icon` attribute is not provided', function() {
 			it('should render the default icon only', function() {
 				expect(component.$$('.user-tile-avatar d2l-icon')).to.exist;
-				expect(component.$$('.user-tile-avatar d2l-image')).to.not.exist;
+				expect(component.$$('.user-tile-avatar img')).to.not.exist;
 			});
 		});
 
@@ -32,7 +32,7 @@ describe('<d2l-user-tile>', function() {
 
 			it('should render the custom icon only', function() {
 				expect(component.$$('.user-tile-avatar d2l-icon')).to.not.exist;
-				expect(component.$$('.user-tile-avatar d2l-image')).to.exist;
+				expect(component.$$('.user-tile-avatar img')).to.exist;
 			});
 		});
 	});

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,23 +13,13 @@
           "version": ""
         },
         {
-          "browserName": "chrome",
-          "platform": "Windows 10",
-          "version": ""
-        },
-        {
-          "browserName": "firefox",
-          "platform": "OS X 10.12",
-          "version": ""
-        },
-        {
           "browserName": "firefox",
           "platform": "Windows 10",
           "version": ""
         },
         {
           "browserName": "safari",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
[US96993 - Use parent permission plugin to allow parents access to user profile image links](https://rally1.rallydev.com/#/157196228032d/detail/userstory/220513268452)

The idea here is that with the addition of parent permissions via the new pluggable permission model the `<d2l-image>` 'hack' of pulling the profile image via the student token should no longer be necessary. This replaces the `<d2l-image>` with a standard `<img>` component and relies on the cookie of the logged in user to gain access to the source image.

This should definitely be considered a breaking change and require a major version bump if released.