### PR TITLE
revert removal of d2l-image

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,7 @@
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.2.0",
     "d2l-colors": "^3.1.2",
     "d2l-icons": "^5.0.0",
+    "d2l-image": "Brightspace/d2l-image#^2.0.0",
     "d2l-organization-hm-behavior": "Brightspace/organization-hm-behavior#^2.0.3",
     "d2l-tile": "^3.0.3",
     "d2l-user-profile-behavior": "Brightspace/user-profile-behavior#^3.0.1",

--- a/d2l-user-tile-auto.html
+++ b/d2l-user-tile-auto.html
@@ -32,6 +32,7 @@
 			icon="[[_iconUrl]]"
 			background="[[_backgroundUrl]]"
 			background-color="[[_backgroundColor]]"
+			token="[[token]]"
 			placeholders="[[!_doneRequests]]"
 		>
 			<slot></slot>

--- a/d2l-user-tile.html
+++ b/d2l-user-tile.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-image/d2l-image.html">
 <link rel="import" href="../d2l-tile/d2l-image-tile.html">
 <link rel="import" href="icons.html">
 <!--
@@ -32,11 +33,6 @@
 				margin: -40px auto 19px auto;
 				background-color: var(--d2l-color-white);
 				overflow: hidden;
-			}
-
-			.user-tile-avatar > img {
-				width: 100%;
-				height: 100%;
 			}
 
 			.user-tile-items {
@@ -109,7 +105,7 @@
 					<d2l-icon icon="navigation-48:profile" class="user-tile-default-icon"></d2l-icon>
 				</template>
 				<template is="dom-if" if="[[_hideIconPlaceholder(icon, _placeholders)]]">
-					<img src=[[icon]] />
+					<d2l-image image-url="[[icon]]" token="[[token]]"></d2l-image>
 				</template>
 			</div>
 			<div class="user-tile-information-wrapper">
@@ -137,6 +133,10 @@
 				type: String,
 				value: null
 			},
+			token: {
+				type: String,
+				value: null
+			},
 			placeholders: {
 				type: Boolean,
 				value: false,
@@ -147,6 +147,10 @@
 				type: Boolean,
 				value: false
 			}
+		},
+
+		listeners: {
+			'd2l-image-failed-to-load': '_onImageLoadFailure'
 		},
 
 		_updatePlaceholders: function(placeholders, oldVal) {
@@ -169,6 +173,10 @@
 
 		_createBackgroundStyle: function(backgroundColor, placeholders) {
 			this.updateStyles({'--d2l-image-tile-image-background': (placeholders) ? '' : backgroundColor || ''});
+		},
+
+		_onImageLoadFailure: function() {
+			this.icon = null;
 		},
 
 		_getImgUrl: function(background, placeholders) {

--- a/test/d2l-user-tile-auto/d2l-user-tile-auto.js
+++ b/test/d2l-user-tile-auto/d2l-user-tile-auto.js
@@ -92,6 +92,7 @@ describe('<d2l-user-tile-auto>', function() {
 
 			it('sets the properties on the internal <d2l-user-tile> appropriately', function(done) {
 				var innerTile = component.$$('d2l-user-tile');
+				sandbox.stub(innerTile, '_onImageLoadFailure', function() {});
 				sandbox.stub(component, 'generateUserRequest', function() {
 					component._name = 'name';
 					component._iconUrl = 'iconUrl';

--- a/test/d2l-user-tile/d2l-user-tile.js
+++ b/test/d2l-user-tile/d2l-user-tile.js
@@ -20,7 +20,7 @@ describe('<d2l-user-tile>', function() {
 		describe('when the `icon` attribute is not provided', function() {
 			it('should render the default icon only', function() {
 				expect(component.$$('.user-tile-avatar d2l-icon')).to.exist;
-				expect(component.$$('.user-tile-avatar img')).to.not.exist;
+				expect(component.$$('.user-tile-avatar d2l-image')).to.not.exist;
 			});
 		});
 
@@ -32,7 +32,7 @@ describe('<d2l-user-tile>', function() {
 
 			it('should render the custom icon only', function() {
 				expect(component.$$('.user-tile-avatar d2l-icon')).to.not.exist;
-				expect(component.$$('.user-tile-avatar img')).to.exist;
+				expect(component.$$('.user-tile-avatar d2l-image')).to.exist;
 			});
 		});
 	});


### PR DESCRIPTION
[US98914 - Revert removal of d2l-image from user-tile, user-switcher, and folio](https://rally1.rallydev.com/#/157196228032d/detail/userstory/240154782788)

This reverts the changes from #50 because we still need to use tokens until we can fix issues with vanity URLs not using the same cookies as the domain returned by our hypermedia APIs. 