### PR TITLE
Accessibility Update

### DIFF
--- a/d2l-user-card.js
+++ b/d2l-user-card.js
@@ -124,7 +124,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-user-card">
 			}
 		</style>
 
-		<d2l-card text="[[name]]" loading$="[[_placeholders]]" href="javascript:void(0);">
+		<d2l-card text="[[_getA11YTitleString(text, name)]]" loading$="[[_placeholders]]" href="javascript:void(0);">
 			<d2l-card-loading-shimmer loading="[[ _placeholders ]]" slot="header">
 				<div class="user-tile-background" style$="[[_getBackgroundStyle(background, backgroundColor)]]"></div>
 			</d2l-card-loading-shimmer>
@@ -174,6 +174,10 @@ Polymer({
 			type: String,
 			value: null
 		},
+		text: {
+			type: String,
+			value: null
+		},
 		token: {
 			type: String,
 			value: null
@@ -214,6 +218,10 @@ Polymer({
 
 	_onImageLoadFailure: function() {
 		this.icon = null;
+	},
+
+	_getA11YTitleString: function(text, name) {
+		return `${text || name}`;
 	},
 
 	_getBackgroundStyle: function(background, backgroundColor) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "user",
     "tile"
   ],
-  "version": "6.0.2",
+  "version": "6.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Brightspace/user-tile.git"


### PR DESCRIPTION
Added support for a text field to set the aria-text instead of forcing the aria text to be the student name.  Defaults to the student name if the new field is missing, so I didn't feel like this needed a major version update.

Part of the following Rally card: https://rally1.rallydev.com/#/detail/userstory/395277400812?fdp=true